### PR TITLE
setting the random seed to a constant value

### DIFF
--- a/webapp/modeling/utils.py
+++ b/webapp/modeling/utils.py
@@ -43,8 +43,8 @@ def select_normalizer(normalization_name):
     return scaler
 
 
-def get_random_seed(extraction_id=None, collection_id=None):
-    return 100000 + collection_id if collection_id else extraction_id
+def get_random_seed():
+    return 42
 
 
 def generate_normalization_methods():

--- a/webapp/service/machine_learning.py
+++ b/webapp/service/machine_learning.py
@@ -190,9 +190,7 @@ def train_model(
     # Convert to numeric values
     labels_df_indexed = labels_df_indexed.apply(pandas.to_numeric)
 
-    random_seed = get_random_seed(
-        extraction_id=extraction_id, collection_id=collection_id
-    )
+    random_seed = get_random_seed()
 
     training_id = get_training_id(extraction_id, collection_id)
 


### PR DESCRIPTION
the random seed was dependant on the collection id and extraction id which hinders reproducibility if you use the same input data from different extractions / different deployment.

Found this out when trying to train the same model on prod vs locally and could not get the same metrics - probably due to random seed issue that was not the same in both deployments.