### PR TITLE
Update: auto-restart dev keycloak and keycloak-db containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
     profiles:
       - dev
     image: quay.io/keycloak/keycloak:16.1.1
+    restart: unless-stopped
     env_file:
       - env_files/common.env
       - env_files/keycloak.env
@@ -134,6 +135,7 @@ services:
     profiles:
       - dev
     image: postgres:17.6
+    restart: unless-stopped
     env_file:
       - env_files/keycloak.env
     secrets:


### PR DESCRIPTION
Both services are behind the dev profile and were the only ones without a restart policy, so they stayed down after a host reboot or crash while the rest of the stack came back. Production uses an independent Keycloak instance and is unaffected.